### PR TITLE
Migrated links to Git repositories to match new locations.

### DIFF
--- a/md/documentation/backend/creating-jetty-bundle.md
+++ b/md/documentation/backend/creating-jetty-bundle.md
@@ -22,7 +22,7 @@ Unzip to a location on your computer. The location will be referenced as {JETTY_
 4) Add configuration to serve Oskari frontend files
 
 - add oskari-front.xml to {JETTY_HOME}/contexts/
-- run 'git clone https://github.com/nls-oskari/oskari' in {JETTY_HOME}
+- run 'git clone https://github.com/oskariorg/oskari-frontend' in {JETTY_HOME}
 - after clone you have for example a file in {JETTY_HOME}/oskari/ReleaseNotes.md
 - optionally modify 'resourceBase' in oskari-front.xml to point to a location where Oskari frontend files are located
 

--- a/md/documentation/backend/custom-install-parcel.md
+++ b/md/documentation/backend/custom-install-parcel.md
@@ -74,7 +74,7 @@ Now you are able to create tables with geometry fields.
 
 2) Get the frontend code from github:
 
-    git clone https://github.com/nls-oskari/oskari.git
+    git clone https://github.com/oskariorg/oskari-frontend.git
 
 3) Rename the created oskari folder to Oskari
 
@@ -86,7 +86,7 @@ Now you are able to create tables with geometry fields.
 
 1) Get the backend code from github:
 
-    git clone https://github.com/nls-oskari/oskari-server.git
+    git clone https://github.com/oskariorg/oskari-server.git
 
 
 

--- a/md/documentation/backend/overview.md
+++ b/md/documentation/backend/overview.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `oskari-server` repository contains Java backend used by [Oskari](https://github.com/nls-oskari/oskari) javascript framework. The backend is modularized and tiered into
+The `oskari-server` repository contains Java backend used by [Oskari](https://github.com/oskariorg/oskari-frontend) javascript framework. The backend is modularized and tiered into
 different types of Maven modules:
 * HTTP API tier: webapps, servlets (also portlets in `oskari-liferay` repository)
 * Control tier: maps HTTP requests into service/database calls.

--- a/md/documentation/backend/setup-development.md
+++ b/md/documentation/backend/setup-development.md
@@ -6,19 +6,19 @@ This document describes how to setup development environment for Oskari.
 
 * JDK 1.7+ (tested with Oracle Java 1.7.0_51 and 1.8.0_05)
 * [Maven 3+](http://maven.apache.org/) (tested with 3.0.5)
-* Git client (http://git-scm.com/) - Optionally download zip file from https://github.com/nls-oskari/oskari-server
+* Git client (http://git-scm.com/) - Optionally download zip file from https://github.com/oskariorg/oskari-server
 * `{JETTY_HOME}` refers to unzipped [Jetty bundle](/download)
 
 ### 1. Fetch Oskari-server source code
 
 With commandline git:
 
-    git clone https://github.com/nls-oskari/oskari-server.git
+    git clone https://github.com/oskariorg/oskari-server.git
 
 Note! You can also download the codes in zip format from Github, but for contributing any changes to Oskari git is mandatory. 
 Additional Maven modules can be contributed outside git though if they are compatible with the current develop/master branch, but this is not adviced.
 
-Note! The frontend source code is already available under `{JETTY_HOME}/oskari` in the [Jetty bundle](/download). To update it you can do `git pull` or replace it with code found in https://github.com/nls-oskari/oskari.
+Note! The frontend source code is already available under `{JETTY_HOME}/oskari` in the [Jetty bundle](/download). To update it you can do `git pull` or replace it with code found in https://github.com/oskariorg/oskari-frontend.
 
 
 ### 2. Build Oskari server

--- a/md/documentation/backend/setup-geoserver.md
+++ b/md/documentation/backend/setup-geoserver.md
@@ -47,7 +47,7 @@ Note! The setup webapp is accessible to anyone once deployed so remove it from `
 
 ### Details for configuring manually/debug purposes
 
-The code for configuring geoserver can be found here: https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/java/fi/nls/oskari/geoserver
+The code for configuring geoserver can be found here: https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/java/fi/nls/oskari/geoserver
 
 1) Create workspace
 
@@ -98,7 +98,7 @@ b) Rendering for WMS
 
 4) Uploads style specific to the functionality
 
-SLD files can be seen here: https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/resources/sld
+SLD files can be seen here: https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/resources/sld
 
 5) Updates layers in database with geoserver info
 

--- a/md/documentation/backend/setup-jetty.md
+++ b/md/documentation/backend/setup-jetty.md
@@ -2,11 +2,11 @@
 
 After this you will have Oskari running including 
 
-- Oskari frontend code (https://github.com/nls-oskari/oskari)
-- Oskari server (map functionality: https://github.com/nls-oskari/oskari-server/tree/master/webapp-map)
-- Oskari transport (WFS services: https://github.com/nls-oskari/oskari-server/tree/master/webapp-transport)
-- Oskari printout (Print services: https://github.com/nls-oskari/oskari-server/tree/master/servlet-printout)
-- Geoserver 2.7.1.1 with WPS-plugin and Oskari extensions (https://github.com/nls-oskari/oskari-server/tree/master/geoserver-ext)
+- Oskari frontend code (https://github.com/oskariorg/oskari-frontend)
+- Oskari server (map functionality: https://github.com/oskariorg/oskari-server/tree/master/webapp-map)
+- Oskari transport (WFS services: https://github.com/oskariorg/oskari-server/tree/master/webapp-transport)
+- Oskari printout (Print services: https://github.com/oskariorg/oskari-server/tree/master/servlet-printout)
+- Geoserver 2.7.1.1 with WPS-plugin and Oskari extensions (https://github.com/oskariorg/oskari-server/tree/master/geoserver-ext)
 
 ### Requirements
 

--- a/md/documentation/backend/setup-server-extension.md
+++ b/md/documentation/backend/setup-server-extension.md
@@ -10,15 +10,15 @@ This document describes how to use maven artifacts provided in Oskari Maven repo
 
 ## 1. Template maven project
 
-[Download](https://github.com/nls-oskari/oskari-server-extension-template) a template for the webapp
+[Download](https://github.com/oskariorg/oskari-server-extension-template) a template for the webapp
 
 ## 2. Start modifying the content
 
-- Edit the `pom.xml`s to change the groupId/artifactId and [oskari.version](https://github.com/nls-oskari/oskari-server-extension-template/blob/ba7fffa3fc4bf7c378ba51edd988131fb0abebaa/pom.xml#L13).
+- Edit the `pom.xml`s to change the groupId/artifactId and [oskari.version](https://github.com/oskariorg/oskari-server-extension-template/blob/ba7fffa3fc4bf7c378ba51edd988131fb0abebaa/pom.xml#L13).
 - Edit the `pom.xml`s to add/change the included dependencies
 - Edit the app-resources to configure app-myapp.json/myapp-view.json/mylayer.json. These are used by default since webapp-map overrides app-default.json.
 - Edit the myapp.jsp under webapp-map to modify the base HTML.
-- Create your own action routes like [MyAction](https://github.com/nls-oskari/oskari-server-extension-template/blob/master/server-extension/src/main/java/my/app/MyActionHandler.java) under server-extension.
+- Create your own action routes like [MyAction](https://github.com/oskariorg/oskari-server-extension-template/blob/master/server-extension/src/main/java/my/app/MyActionHandler.java) under server-extension.
 
 The released Oskari artifacts are downloaded from oskari.org Maven repository:
 

--- a/md/documentation/backend/thematicmaps/config.md
+++ b/md/documentation/backend/thematicmaps/config.md
@@ -83,7 +83,7 @@ Plugins or adapters are used to interpret the statistics data API to a common fo
 
 Eurostat is the statistical office of the European Union situated in Luxembourg. Its mission is to provide high quality statistics for Europe. They offer an API that uses SDMX and JSON-stat as dataformats.
 
-Code: https://github.com/nls-oskari/oskari-server/blob/develop/service-statistics-eurostat/src/main/java/fi/nls/oskari/statistics/eurostat/EurostatStatisticalDatasourceFactory.java
+Code: https://github.com/oskariorg/oskari-server/blob/develop/service-statistics-eurostat/src/main/java/fi/nls/oskari/statistics/eurostat/EurostatStatisticalDatasourceFactory.java
 
 Datasource config:
 
@@ -95,7 +95,7 @@ Datasource config:
 
 PX-Web is a widely used statistics software that offers an API for accessing the data.
 
-Code: https://github.com/nls-oskari/oskari-server/blob/develop/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourceFactory.java
+Code: https://github.com/oskariorg/oskari-server/blob/develop/service-statistics-pxweb/src/main/java/fi/nls/oskari/control/statistics/plugins/pxweb/PxwebStatisticalDatasourceFactory.java
 
 Datasource config:
 
@@ -109,7 +109,7 @@ Datasource config:
 
 The Sotkanet Indicator Bank is an API provided by Finnish National Institute for Health and Welfare (THL). It is also used by National Land Survey of Finland to share statistics.
 
-Code: https://github.com/nls-oskari/oskari-server/blob/develop/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaStatisticalDatasourceFactory.java
+Code: https://github.com/oskariorg/oskari-server/blob/develop/service-statistics-sotka/src/main/java/fi/nls/oskari/control/statistics/plugins/sotka/SotkaStatisticalDatasourceFactory.java
 
 Datasource config:
 

--- a/md/documentation/backend/thematicmaps/requirements.md
+++ b/md/documentation/backend/thematicmaps/requirements.md
@@ -25,7 +25,7 @@ The sample application has this enabled by default, but there is no sample Flywa
 
 The actual thematic maps user interface is provided by another bundle: statsgrid that needs to be added to the geoportal views.
 
-You can use a Flyway-migration to add it in your own server-extension. Here's an example for the sample application: https://github.com/nls-oskari/oskari-server/blob/master/content-resources/src/main/java/flyway/sample/V1_0_8__add_statsgrid_to_default_views.java
+You can use a Flyway-migration to add it in your own server-extension. Here's an example for the sample application: https://github.com/oskariorg/oskari-server/blob/master/content-resources/src/main/java/flyway/sample/V1_0_8__add_statsgrid_to_default_views.java
 
 Or you can add it manually into the database by replacing [view_id] in the SQL below:
 
@@ -52,11 +52,11 @@ Remember to add the statsgrid bundle to you minifierAppSetup.json as well under 
         }
     }
 
-The sample application has it included as an example: https://github.com/nls-oskari/oskari/blob/1.40.0/applications/sample/servlet/minifierAppSetup.json#L578-L587. Remember to add mapstats from the previous step to the minifierAppSetup.json as well:
+The sample application has it included as an example: https://github.com/oskariorg/oskari-frontend/blob/1.40.0/applications/sample/servlet/minifierAppSetup.json#L578-L587. Remember to add mapstats from the previous step to the minifierAppSetup.json as well:
 
-https://github.com/nls-oskari/oskari/blob/1.40.0/applications/sample/servlet/minifierAppSetup.json#L71-L73
+https://github.com/oskariorg/oskari-frontend/blob/1.40.0/applications/sample/servlet/minifierAppSetup.json#L71-L73
 
-https://github.com/nls-oskari/oskari/blob/1.40.0/applications/sample/servlet_published_ol3/minifierAppSetup.json#L12-L14
+https://github.com/oskariorg/oskari-frontend/blob/1.40.0/applications/sample/servlet_published_ol3/minifierAppSetup.json#L12-L14
 
 After this you should have the bundle included in both minifierAppSetups and the actual GetAppSetup response (database table portti_view_bundle_seq). 
 
@@ -87,7 +87,7 @@ The server-side code for thematic maps are included by default on the sample app
         </dependency>
         <!-- /Statistics plugins -->
 
-Take a look at the sample webapp-map for details: https://github.com/nls-oskari/oskari-server/blob/1.40.0/webapp-map/pom.xml#L58-L71. There might be additional adapters available also. Take a look at the folders under oskari-server starting with 'service-statistics-'.
+Take a look at the sample webapp-map for details: https://github.com/oskariorg/oskari-server/blob/1.40.0/webapp-map/pom.xml#L58-L71. There might be additional adapters available also. Take a look at the folders under oskari-server starting with 'service-statistics-'.
 
 # Next step
 

--- a/md/documentation/backend/upgrade_scripts.md
+++ b/md/documentation/backend/upgrade_scripts.md
@@ -33,8 +33,8 @@ In a basic maven setup this will result in files like these:
 
 Existing scripts can be found in Github:
 
- - SQL: https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/resources/flyway
- - Java: https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/java/flyway
+ - SQL: https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/resources/flyway
+ - Java: https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/java/flyway
  
 Application-specific upgrade example:
 - Java: https://github.com/arctic-sdi/oskari-server-extensions/tree/develop/server-extension/src/main/java/flyway/asdi

--- a/md/documentation/backend/upgrading.md
+++ b/md/documentation/backend/upgrading.md
@@ -28,8 +28,8 @@ in table named `oskari_status`. Each module can also have their own datasource w
 a common datasource is used (`jdbc/OskariPool`).
 
 The upgrade scripts can be found in Github:
- - SQL: https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/resources/flyway
- - Java: https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/java/flyway
+ - SQL: https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/resources/flyway
+ - Java: https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/java/flyway
 
 ## Troubleshooting
 
@@ -243,8 +243,8 @@ The database needs to be updated manually to a state of version 1.30.x. After th
  BUT expects the manual upgrades have been done until version 1.30.x. 
 
 Database upgrade SQL scripts are located under `oskari-server/content-resources/src/main/resources/sql/upgrade/{version}`. SQL scripts can also be found behind these links in github:
-- https://github.com/nls-oskari/oskari-server/tree/master/content-resources/src/main/resources/sql/upgrade
-- https://github.com/nls-oskari/oskari-server/tree/develop/content-resources/src/main/resources/sql/upgrade
+- https://github.com/oskariorg/oskari-server/tree/master/content-resources/src/main/resources/sql/upgrade
+- https://github.com/oskariorg/oskari-server/tree/develop/content-resources/src/main/resources/sql/upgrade
 
 There's also `node.js` based upgrade tool under `oskari-server/content-resources/db-upgrade` which is mainly used for updating database content, for instance for adding plugins to the default view.
 This is replaced by the Java upgrades on Oskari 1.31.0.

--- a/md/documentation/backend/usermanagement.md
+++ b/md/documentation/backend/usermanagement.md
@@ -43,7 +43,7 @@ If you are running an oskari-server-extension you need to also add the dependenc
     <groupId>fi.nls.oskari.service</groupId>
     <artifactId>oskari-control-users</artifactId>
 
-The functionality is mostly contained under [oskari-server/control-users](https://github.com/nls-oskari/oskari-server/tree/develop/control-users) with JSPs that can be overridden
-in oskari-server-extensions using the same filename as the original. There are also localizations for the user registration that can be overridden with [locale/messages-ext.properties](https://github.com/nls-oskari/oskari-server/blob/develop/servlet-map/src/main/resources/locale/messages.properties) files in the server classpath.
+The functionality is mostly contained under [oskari-server/control-users](https://github.com/oskariorg/oskari-server/tree/develop/control-users) with JSPs that can be overridden
+in oskari-server-extensions using the same filename as the original. There are also localizations for the user registration that can be overridden with [locale/messages-ext.properties](https://github.com/oskariorg/oskari-server/blob/develop/servlet-map/src/main/resources/locale/messages.properties) files in the server classpath.
 
 Note! User registration has been tested/implemented only for the case where users are in the Oskari database. Not for SAML logins etc.

--- a/md/documentation/configuring_map_projection.md
+++ b/md/documentation/configuring_map_projection.md
@@ -84,7 +84,7 @@ The bounds can be found f. e. in [spatial reference web site](http://spatialrefe
 
 **projectionDefs** should include [proj4js](http://proj4js.org/) configurations for all the projections that are going to be used in the application.
 The oskari-server will try to detect the projections that are used and inject the projectionDefs automatically. The projectionDefs are stored in this
-file: https://github.com/nls-oskari/oskari-server/blob/master/control-base/src/main/resources/fi/nls/oskari/control/view/modifier/bundle/epsg_proj4_formats.json.
+file: https://github.com/oskariorg/oskari-server/blob/master/control-base/src/main/resources/fi/nls/oskari/control/view/modifier/bundle/epsg_proj4_formats.json.
 If the projection you want to use isn't available in the file you can insert the definition manually to the database config or make a pull request/issue to oskari-server
  to add the missing projection to the epsg_proj4_formats.json file.
 
@@ -105,7 +105,7 @@ The projection can be configured to the database with the following kind of SQL.
 
 For user content like myplaces, analysis and userlayers one "native" projection is required for Geoserver config. 
 The easiest way to do this is use the "setup" webapp provided in the Jetty Oskari package. It uses the geoserver REST API to configure workspace, stores, layers and styles for user-generated content.
-The code is available in [Github](https://github.com/nls-oskari/oskari-server/tree/master/webapp-setup) and a precompiled deployable war-file is included in the Jetty-package available for 
+The code is available in [Github](https://github.com/oskariorg/oskari-server/tree/master/webapp-setup) and a precompiled deployable war-file is included in the Jetty-package available for 
 download on [Oskari.org](/download). Just deploy the webapp and access it in browser.
 
 Accessing the webapp will ask for the native projection to use for user-generated content and configure the geoserver configured in oskari-ext.properties:

--- a/md/documentation/core-concepts/map-plugin.md
+++ b/md/documentation/core-concepts/map-plugin.md
@@ -2,7 +2,7 @@
 
 Map View Plugins are used to add required functionality to the map view without editing the framework using a consistent pattern. Map Module plugins may be distributed within bundles and registered as bundle is instantiated. The default Map View is implemented in bundle `mapmodule-plugin`. Default implementation is based on OpenLayers Map. Some OpenLayers specific code is spread across sources but there's been an attempt to isolate OpenLayers specific code to enable switching to 'the best map framework' in the future. Plugin provides access to OpenLayers Map primitives.
 
-[Map Module Plugin Protocol (interface)](https://github.com/nls-oskari/oskari/blob/master/bundles/framework/bundle/mapmodule-plugin/plugin/Plugin.js)
+[Map Module Plugin Protocol (interface)](https://github.com/oskariorg/oskari-frontend/blob/master/bundles/framework/bundle/mapmodule-plugin/plugin/Plugin.js)
 
 
 ## Registering and starting a Plugin

--- a/md/documentation/data/maplayer-definitions.md
+++ b/md/documentation/data/maplayer-definitions.md
@@ -30,7 +30,7 @@ WFS layer is based on features described with GML as opposed to WMS image tiles.
 
 WFS layers can be queried and data for the features displayed in the view port can be shown on a data table. WFS features can also be highlighted by clicking them on map or by selecting it in the data table. This functionality is implemented in bundles `mapwfs2` (display) and `featuredata` (data table).
 
-See [here](https://github.com/nls-oskari/oskari/blob/master/docs/md/architecture/wfs.md) and [here](http://oskari.org/documentation/architecture/wfs) for more complete documentation.
+See [here](https://github.com/oskariorg/oskari-frontend/blob/master/docs/md/architecture/wfs.md) and [here](http://oskari.org/documentation/architecture/wfs) for more complete documentation.
 
 [data format explained](/documentation/data/wfs-layer)
 

--- a/md/documentation/development-environment.md
+++ b/md/documentation/development-environment.md
@@ -5,7 +5,7 @@ How to get set up your Oskari development environment
 ### 1. GitHub, the collaboration platform
 
 The Oskari source code is stored in several separate Git repositories hosted under the [nls-
-oskari](https://github.com/nls-oskari) organization on GitHub.
+oskari](https://github.com/oskariorg) organization on GitHub.
 
 The source code projects on GitHub also facilitate collaboration through hosting the project's
 external bug / ticket trackers.
@@ -26,7 +26,7 @@ Watch:
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/ijaaL_G6Jgo" frameborder="0" allowfullscreen></iframe>
 
-Fork the nls-oskari/oskari and nls-oskari/oskari-server repositories, and check out the source code
+Fork the oskariorg/oskari and oskariorg/oskari-server repositories, and check out the source code
 from your forks to your local computer.
 
 Read Atlassian's [Git Flow documentation](https://www.atlassian.com/git/tutorials/comparing-
@@ -45,16 +45,15 @@ A successfully installed Git Flow plugin can be validated by running the command
 
 #### 1.2 Oskari source code
 
-The `github.com/nls-oskari/oskari` repository contains the frontend JavaScript, CSS and HTML source
+The `github.com/oskariorg/oskari-frontend` repository contains the frontend JavaScript, CSS and HTML source
 code. It assumes being served from webserver path /Oskari with a capital O so you can checkout the repository under the name `Oskari` or configure the webserver to do this. The [Jetty bundle](/download) is configured properly for this. 
 
-The `github.com/nls-oskari/oskari-server` contains the Oskari serverside code and `github.com/nls-oskari/oskari-liferay` contains a Liferay 6.0.6 portlet replacement for the webapp in oskari-server.
+The `github.com/oskariorg/oskari-server` contains the Oskari serverside code and `github.com/nls-oskari/oskari-liferay` contains a Liferay 6.0.6 portlet replacement for the webapp in oskari-server.
 
 #### 1.3 Licensing
 
-The Oskari source code is dual licensed with [EUPL](https://github.com/nls-oskari/oskari-
-server/raw/master/LICENSE-EUPL.pdf) and the [MIT](https://github.com/nls-oskari/oskari-
-server/blob/master/LICENSE-MIT.txt) licenses, which are made available in the source code
+The Oskari source code is dual licensed with [EUPL](https://github.com/oskariorg/oskari-server/raw/master/LICENSE-EUPL.pdf)
+and the [MIT](https://github.com/oskariorg/oskari-server/blob/master/LICENSE-MIT.txt) licenses, which are made available in the source code
 repositories.
 
 Not all of the source code files contain a license header.
@@ -111,7 +110,7 @@ using Node.js tooling.
 Therefore, a developer must install a platform-appropriate Node.js execution and runtime
 environment, along with the NPM package manager and Grunt build tool.
 
-Unfortunately the `nls-oskari/oskari` repository currently has only Windows-specific build scripts,
+Unfortunately the `oskariorg/oskari-frontend` repository currently has only Windows-specific build scripts,
 but they are trivial, and can be translated into a `bash` script suitable for Mac OS X and Linux
 with a minimal effort.
 

--- a/md/documentation/development/how-to-contribute.md
+++ b/md/documentation/development/how-to-contribute.md
@@ -3,7 +3,7 @@
 The preferred way of contributing to Oskari in a nutshell:
 
 1. Familiarize yourself with the [license terms](/documentation/development/license)
-2. Fork [oskari](https://github.com/nls-oskari/oskari), [oskari-server](https://github.com/nls-oskari/oskari-server) or [oskari-liferay](https://github.com/nls-oskari/oskari-liferay) on GitHub 
+2. Fork [oskari](https://github.com/oskariorg/oskari-frontend), [oskari-server](https://github.com/oskariorg/oskari-server) or [oskari-liferay](https://github.com/nls-oskari/oskari-liferay) on GitHub 
 3. Develop your code in a feature branch. For the curious, here's a look of the [internal git process used by NLS](/documentation/development/oskari-git-process) for Oskari development.
 4. Notify us when the code is ready for QA and integration testing (GitHub pull request, email, anything really) 
  

--- a/md/documentation/development/license.md
+++ b/md/documentation/development/license.md
@@ -9,8 +9,8 @@ Contributor License Agreement
 
 * The same CLA applies to all git repositories. 
 
-	* [Oskari frontend](https://github.com/nls-oskari/oskari/blob/master/CLA.txt)
-	* [Oskari server](https://github.com/nls-oskari/oskari-server/blob/master/CLA.txt)
+	* [Oskari frontend](https://github.com/oskariorg/oskari-frontend/blob/master/CLA.txt)
+	* [Oskari server](https://github.com/oskariorg/oskari-server/blob/master/CLA.txt)
 	* [Oskari liferay](https://github.com/nls-oskari/oskari-liferay/blob/develop/CLA.txt)
 
 3rd party JavaScript libraries

--- a/md/documentation/examples/rpc-control.md
+++ b/md/documentation/examples/rpc-control.md
@@ -4,7 +4,7 @@ This guide is originally made for Inspire conference workshop. The aim is to dem
 
 The case is that an organization has an existing [website](/examples/rpc-control/) including functionality for [reporting road condition issues](/examples/rpc-control/mapservice_base.html). The location information is address based, but we want to use a map instead. We will first build a [simple](/examples/rpc-control/mapservice_step1.html) map interface, then adjust it to enable reporting of [environmental issues](/examples/rpc-control/mapservice_step2.html) as well and last add some [social features](/examples/rpc-control/mapservice_step3.html). This is done by controlling the map from the embedding page.
 
-The source code for this demo can be found in [GitHub](https://github.com/nls-oskari/oskari.org/tree/master/public/examples/rpc-control).
+The source code for this demo can be found in [GitHub](https://github.com/oskariorg/oskari-docs/tree/master/public/examples/rpc-control).
 
 ## Getting started
 

--- a/md/documentation/frontend/override-locales.md
+++ b/md/documentation/frontend/override-locales.md
@@ -77,5 +77,5 @@ placing it first in startupSequence and minifierAppsetup.json.
 
 # Example bundle
 
-You can use [this bundle](https://github.com/nls-oskari/oskari/blob/develop/packages/elf/bundle/elf-lang-overrides/bundle.js) as an example.
+You can use [this bundle](https://github.com/oskariorg/oskari-frontend/blob/develop/packages/elf/bundle/elf-lang-overrides/bundle.js) as an example.
 

--- a/md/documentation/minification.md
+++ b/md/documentation/minification.md
@@ -1,6 +1,6 @@
 # Frontend-tools
 
-There are some helpful tools under Oskari/tools folder under the Oskari frontend [repository](https://github.com/nls-oskari/oskari). To use them you need to:
+There are some helpful tools under Oskari/tools folder under the Oskari frontend [repository](https://github.com/oskariorg/oskari-frontend). To use them you need to:
 
 1) install nodejs version 5+ (tested on 5.x and 6.x)
 
@@ -16,7 +16,7 @@ The minifying process also generates a sprite image for the generic tools icons 
 
 Minifying the code means that all the files that are needed to build the app are put in a single file and all the "human-friendly" names are changed to be more compact. This will reduce the startup time for the end-user dramatically. With the default download and sample application you can run `npm run build` to generate the minified Javascript files. This will result in `Oskari/dist/servlet` folder being generated.
 
-This works by reading a minifierAppSetup.json file that should match the appsetup (bundle-collection) used on the website including any dynamic (role-based) bundles that are added on the fly. So basically all the bundles you want to use. Here's an example for the basic [geoportal appsetup](https://github.com/nls-oskari/oskari/blob/master/applications/sample/servlet/minifierAppSetup.json) and for an [embedded map](https://github.com/nls-oskari/oskari/blob/master/applications/sample/servlet_published_ol3/minifierAppSetup.json). These are used when running just `npm run build`. If you take a look at the package.json [script-definitions for builds](https://github.com/nls-oskari/oskari/blob/master/tools/package.json) you can see that you can also specify the version and the minifierAppSetups to use for your needs by running a modified command from what are used as the script shortcuts.
+This works by reading a minifierAppSetup.json file that should match the appsetup (bundle-collection) used on the website including any dynamic (role-based) bundles that are added on the fly. So basically all the bundles you want to use. Here's an example for the basic [geoportal appsetup](https://github.com/oskariorg/oskari-frontend/blob/master/applications/sample/servlet/minifierAppSetup.json) and for an [embedded map](https://github.com/oskariorg/oskari-frontend/blob/master/applications/sample/servlet_published_ol3/minifierAppSetup.json). These are used when running just `npm run build`. If you take a look at the package.json [script-definitions for builds](https://github.com/oskariorg/oskari-frontend/blob/master/tools/package.json) you can see that you can also specify the version and the minifierAppSetups to use for your needs by running a modified command from what are used as the script shortcuts.
 
 The easiest modification with most benefit is changing the minifierAppSetup.json files to only include the bundles that you are using. This reduces the amount of code the end-user needs to load. You can also safely rename the "version" folder from `dist/servlet` to `dist/1.0` or similar. Note that you will need to tell the server what client version to serve. This is done by modifying the `oskari-ext.properties` file:
 

--- a/md/guides/nginx-config.md
+++ b/md/guides/nginx-config.md
@@ -5,7 +5,7 @@ The latest nginx version at the time of writing is 1.8.1 which has been used to 
 
 *Using a reverse proxy is not required for development, but is recommended for production use*
 
-You can find example configurations in https://github.com/nls-oskari/sample-configs/tree/master/nginx
+You can find example configurations in https://github.com/oskariorg/sample-configs/tree/master/nginx
 
 ![Diagram for nginx proxy](/images/documentation/nginx.png)
 

--- a/md/guides/rpc-step-by-step.md
+++ b/md/guides/rpc-step-by-step.md
@@ -5,7 +5,7 @@ This guide will tell you how to control a published map from the parent document
 ## What do I need?
 
 * published map (map can be published for example at http://www.paikkatietoikkuna.fi/)
-* OskariRPC.js (available on GitHub: https://github.com/nls-oskari/rpc-client)
+* OskariRPC.js (available on GitHub: https://github.com/oskariorg/rpc-client)
 * jschannel.js (available on GitHub: https://github.com/yochannah/jschannel)
 * The html-document in which you want to use a map with functionalities
 * basic knowledge of javascript

--- a/public/examples/rpc-api/rpc_example.html
+++ b/public/examples/rpc-api/rpc_example.html
@@ -135,7 +135,7 @@
     <div style="display: none; visibility: hidden;" id="gettingStarted">
         <h3>Including the necessary stuff to get RPC up and running</h3>
         <div>Including RPC javascript in html available from:<br />
-            <a href="https://github.com/nls-oskari/rpc-client/tree/master/dist" target="_blank">https://github.com/nls-oskari/rpc-client/tree/master/dist</a></div>
+            <a href="https://github.com/oskariorg/rpc-client/tree/master/dist" target="_blank">https://github.com/oskariorg/rpc-client/tree/master/dist</a></div>
         <pre>
             <code class="lang-html hljs xml">
 &lt;script src="js/rpc-client.js"&gt;&lt;/script&gt;

--- a/views/_footer.jade
+++ b/views/_footer.jade
@@ -1,4 +1,4 @@
 :markdown
   Coordinator: [National Land Survey of Finland](http://www.maanmittauslaitos.fi/en) - 2016 |
-  [Fork me on GitHub](https://github.com/nls-oskari/) |
+  [Fork me on GitHub](https://github.com/oskariorg/) |
   [Oskari on Twitter](https://twitter.com/oskari_org)

--- a/views/about.jade
+++ b/views/about.jade
@@ -13,7 +13,7 @@ block main
         JavaScript and/or Java development is required to read and understand the frontend and
         the backend documentation, respectively.
 
-        The source code and content can be found on [Github](https://github.com/nls-oskari/oskari.org).
+        The source code and content can be found on [Github](https://github.com/oskariorg/oskari-docs).
         If you have any additions, suggestions or corrections to the content of the site, [please make a pull](/documentation/development/how-to-contribute) request.
         Your help is greatly appreciated!
 
@@ -52,10 +52,10 @@ block main
           :markdown
             ### GitHub
             We welcome contributions to the Oskari GitHub repository:
-            https://github.com/nls-oskari
+            https://github.com/oskariorg
 
             Issues can also be reported through GitHub:
-            https://github.com/nls-oskari/oskari/issues
+            https://github.com/oskariorg/oskari-frontend/issues
 
 
 

--- a/views/challenge.jade
+++ b/views/challenge.jade
@@ -34,7 +34,7 @@ block main
 
           ### How to take part in Oskari Challenge
 
-          1.  Branch or Download Oskari source code version 1.23 or later. Source code can be found in GitHub at https://github.com/nls-oskari or through http://www.oskari.org/download 
+          1.  Branch or Download Oskari source code version 1.23 or later. Source code can be found in GitHub at https://github.com/oskariorg or through http://www.oskari.org/download 
           2.  Develop your application
           3.  Make the code available through GitHub
           4.  Write a short description of the proposal with screenshots, slideshow or a video of the application or the concept

--- a/views/documentation.jade
+++ b/views/documentation.jade
@@ -71,7 +71,7 @@ block main
 
           div.panel-body
             :markdown
-                The user interface is a [Javascript-based](https://github.com/nls-oskari/oskari) single-page app built by selecting a series of [modules](/api/bundles) that provide features for an application. The modules provide a documented API for interaction and/or easy replacement for a new implementation of a feature. You can mix and match the modules or create new ones to customize the application for your needs.
+                The user interface is a [Javascript-based](https://github.com/oskariorg/oskari-frontend) single-page app built by selecting a series of [modules](/api/bundles) that provide features for an application. The modules provide a documented API for interaction and/or easy replacement for a new implementation of a feature. You can mix and match the modules or create new ones to customize the application for your needs.
 
             div.row
               div.col-md-4
@@ -132,7 +132,7 @@ block main
 
           div.panel-body
             :markdown
-              The [oskari-server](https://github.com/nls-oskari/oskari-server) is built with Java and Maven. It provides deployable webapps for managing and launching the user interface for Oskari-based apps. It also provides [endpoints (action routes)](/documentation/backend/actionroutes) for http-requests triggered by the frontend.
+              The [oskari-server](https://github.com/oskariorg/oskari-server) is built with Java and Maven. It provides deployable webapps for managing and launching the user interface for Oskari-based apps. It also provides [endpoints (action routes)](/documentation/backend/actionroutes) for http-requests triggered by the frontend.
 
             div.row
               div.col-md-4

--- a/views/download.jade
+++ b/views/download.jade
@@ -22,15 +22,15 @@ block main
                         p  Includes prebuilt and configured:
                             ul
                                 li Oskari frontend code (
-                                    a(href="https://github.com/nls-oskari/oskari", target="_blank") https://github.com/nls-oskari/oskari)
+                                    a(href="https://github.com/oskariorg/oskari-frontend", target="_blank") https://github.com/oskariorg/oskari-frontend)
                                 li Oskari server (map functionality:
-                                    a(href="https://github.com/nls-oskari/oskari-server/tree/master/webapp-map", target="_blank")  https://github.com/nls-oskari/oskari-server/tree/master/webapp-map)
+                                    a(href="https://github.com/oskariorg/oskari-server/tree/master/webapp-map", target="_blank")  https://github.com/oskariorg/oskari-server/tree/master/webapp-map)
                                 li Oskari transport (WFS services:
-                                    a(href="https://github.com/nls-oskari/oskari-server/tree/master/webapp-transport", target="_blank")  https://github.com/nls-oskari/oskari-server/tree/master/webapp-transport)
+                                    a(href="https://github.com/oskariorg/oskari-server/tree/master/webapp-transport", target="_blank")  https://github.com/oskariorg/oskari-server/tree/master/webapp-transport)
                                 li Oskari printout (Print services:
-                                    a(href="https://github.com/nls-oskari/oskari-server/tree/master/servlet-printout", target="_blank")  https://github.com/nls-oskari/oskari-server/tree/master/servlet-printout)
+                                    a(href="https://github.com/oskariorg/oskari-server/tree/master/servlet-printout", target="_blank")  https://github.com/oskariorg/oskari-server/tree/master/servlet-printout)
                                 li Geoserver 2.7.1.1 with WPS-plugin and Oskari extensions (
-                                    a(href="https://github.com/nls-oskari/oskari-server/tree/master/geoserver-ext", target="_blank") https://github.com/nls-oskari/oskari-server/tree/master/geoserver-ext)
+                                    a(href="https://github.com/oskariorg/oskari-server/tree/master/geoserver-ext", target="_blank") https://github.com/oskariorg/oskari-server/tree/master/geoserver-ext)
 
 
     div.row
@@ -38,12 +38,12 @@ block main
 
             ## Github repositories
 
-            * [Oskari JavaScript framework](https://github.com/nls-oskari/oskari)
-            * [Oskari Server](https://github.com/nls-oskari/oskari-server)
-            * [Maven template for extending oskari-server functionality](https://github.com/nls-oskari/oskari-server-extension-template)
-            * [Sample configurations](https://github.com/nls-oskari/sample-configs)
-            * [RPC client library](https://github.com/nls-oskari/rpc-client)
-            * [Oskari.org site](https://github.com/nls-oskari/oskari.org)
+            * [Oskari JavaScript framework](https://github.com/oskariorg/oskari-frontend)
+            * [Oskari Server](https://github.com/oskariorg/oskari-server)
+            * [Maven template for extending oskari-server functionality](https://github.com/oskariorg/oskari-server-extension-template)
+            * [Sample configurations](https://github.com/oskariorg/sample-configs)
+            * [RPC client library](https://github.com/oskariorg/rpc-client)
+            * [Oskari.org site](https://github.com/oskariorg/oskari-docs)
             * [Liferay 6.0.6 wrapper for Oskari Server](https://github.com/nls-oskari/oskari-liferay)
 
             Master branch has stable production ready code that is in use for example at ​[Demo.oskari.org](http://demo.oskari.org) and ​[Paikkatietoikkuna.fi](http://www.paikkatietoikkuna.fi/web/en).

--- a/views/examples.jade
+++ b/views/examples.jade
@@ -49,7 +49,7 @@ block main
       div.col-md-4
         div.panel.panel-warning.panelexample
           div.panel-heading
-            h4. Hallinnon karttapalvelu
+            h4. Suomi.fi Maps
 
           div.panel-body
             :markdown

--- a/views/oskari.jade
+++ b/views/oskari.jade
@@ -73,7 +73,7 @@ block main
               ### Oskari is in use at:
               * [Finnish Geoportal](http://www.paikkatietoikkuna.fi/web/en/map-window)
               * [Geoportal of Tampere city](http://paikkatietopalvelu.tampere.fi/)
-              * [NLS: Hallinnon karttapalvelu](http://www.maanmittauslaitos.fi/aineistot-palvelut/verkkopalvelut/hallinnon-karttapalvelu/palvelun-esittely/esimerkkeja)
+              * [NLS: Suomi.fi Maps](http://www.maanmittauslaitos.fi/asioi-verkossa/suomifi-kartat)
               * [NLS: File service of open data](https://tiedostopalvelu.maanmittauslaitos.fi/tp/kartta?lang=en)
               * [NLS: Old printed maps](http://vanhatpainetutkartat.maanmittauslaitos.fi/?lang=en)
               * [Lupapiste](https://www.lupapiste.fi/)


### PR DESCRIPTION
Mass migrated repository urls to match new locations under the oskariorg organisation (nls-oskari/oskari to oskariorg/oskari-frontend etc.).

No other content was touched except changing the service name Hallinnon karttapalvelu
to Suomi.fi Maps.