### PR TITLE
Updated thematic maps docs for Oskari 2.0

### DIFF
--- a/md/documentation/features/thematicmaps/config.md
+++ b/md/documentation/features/thematicmaps/config.md
@@ -153,7 +153,7 @@ Not all datasources have data for all of the regionsets so as the last step you 
 
 
     INSERT INTO 
-        oskari_statistical_layer(datasource_id, layer_id, config)
+        oskari_statistical_datasource_regionsets(datasource_id, layer_id, config)
     VALUES(
         (SELECT id FROM oskari_statistical_datasource 
             WHERE locale like '%Health and Welfare%'),

--- a/md/documentation/features/thematicmaps/requirements.md
+++ b/md/documentation/features/thematicmaps/requirements.md
@@ -2,92 +2,116 @@
 
 *Note! This functionality uses Redis heavily for caching so it needs to be available for the server to work properly.*
 
-## Frontend statslayer support
+## Frontend
 
-The StatsLayerPlugin provides support for the statslayer type maplayers. The map visualization is done by these layers and the regions for a regionset is also fetched from the layer. The plugin needs to be started with mapfull-bundles config referencing it in the plugins array:
+These are actions that enable the functionality to work on your apps.
 
-    { "id" : "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin" }
+### Vector features support
 
-The code is provided by the mapstats bundle and it needs to be loaded in the  startupSequence in mapfull-bundle imports:
+The VectorLayerPlugin provides support for the adding vector features to the map and is required for thematic maps to work properly. The map visualization is done by adding regions for a region set as vector features to the map. The plugin needs to be started with `mapfull` bundles config referencing it in the plugins array:
 
-    "mapstats": {
-        "bundlePath": "/Oskari/packages/mapping/ol2/"
-    }
+    { "id" : "Oskari.mapframework.mapmodule.VectorLayerPlugin" }
 
-for Openlayers 2 the bundlePath is /Oskari/packages/mapping/ol2/
-for Openlayers 3 the bundlePath is /Oskari/packages/mapping/ol3/
+The code for VectorLayerPlugin is included in the mapmodule and the sample application has it in the configuration so you shouldn't really need to do anything about it but if you don't see any regions on the map this can be the cause.
 
-In most cases this means that the main "geoportal" appsetups (views of type USER and DEFAULT in portti_view database table) should include the ol2 while the publish-template and any published maps (views of type PUBLISH and PUBLISHED in portti_view database table) should have the ol3 implementation.
+If you for some reason don't have you should do an application specific Flyway-migration to add the plugin to the appsetups that you need it in. See server section for details.
 
-The sample application has this enabled by default, but there is no sample Flyway-script to enable it to a customized application. Here's an example for adding the plugin with flyway if you need one: https://github.com/arctic-sdi/oskari-server-extensions/blob/develop/server-extension/src/main/java/flyway/asdi/V1_5_1__Add_marker_support.java. Just change the PLUGIN_NAME to "Oskari.mapframework.bundle.mapstats.plugin.StatsLayerPlugin" and the version in the class name to fit you app-specific Flyway-module.
+### User-interface for thematic maps
 
-## Geoportal user interface
+For bundling in the user interface you will need to include the `statsgrid` bundle in your applications `main.js`.
+
+If you always show it for users you should use this to include it on the application:
+
+```javascript
+import 'oskari-loader!oskari-frontend/packages/statistics/statsgrid/bundle.js';
+```
+
+OR if you want to show it to only some users you can reduce the amount of code all users need to download by using the "lazy loader". For example on the embedded map application you want to use this since most of the embedded maps don't usually include thematic maps:
+
+```javascript
+import 'oskari-lazy-loader?statsgrid!oskari-frontend/packages/statistics/statsgrid/bundle.js';
+```
+
+After modifying the main.js you will need to run `npm run build` to update the build artifacts in the `dist/[version]` folder.
+
+After building a new version with the statsgrid bundle included you can test it out in the browser by running this on the developer console:
+
+```javascript
+Oskari.app.playBundle({ bundlename : 'statsgrid' });
+```
+
+You should see the user-interface for the functionality show up on the geoportal page.
+
+## Server
+
+### Adding the functionality to geoportal user interface
+
+After bundling in the functionality on the frontend build you will need to tell the server to start the functionality in the appsetups you want to use it with. Usually this is all appsetups of type `USER` and `DEFAULT`.
 
 The actual thematic maps user interface is provided by another bundle: statsgrid that needs to be added to the geoportal views.
 
-You can use a Flyway-migration to add it in your own server-extension. Here's an example for the sample application: https://github.com/oskariorg/oskari-server/blob/master/content-resources/src/main/java/flyway/sample/V1_0_8__add_statsgrid_to_default_views.java
+You can use a Flyway-migration to add it in your own server-extension:
 
-Or you can add it manually into the database by replacing [view_id] in the SQL below:
+```java
+package flyway.[your module];
 
-    INSERT INTO portti_view_bundle_seq (view_id, seqno, bundle_id, startup, config, state)
-           VALUES ([view_id],
-            (SELECT (max(seqno) + 1) FROM portti_view_bundle_seq WHERE view_id = [view_id]),
-            (SELECT id FROM portti_bundle WHERE name = 'statsgrid'),
-            (SELECT startup FROM portti_bundle WHERE name = 'statsgrid'),
-            (SELECT config FROM portti_bundle WHERE name = 'statsgrid'),
-            (SELECT state FROM portti_bundle WHERE name = 'statsgrid'));
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.oskari.helpers.AppSetupHelper;
 
-*Note!* You don't need to add the statsgrid bundle to publish-template or any embedded maps. If the user decides to publish a thematic map, the bundle is automatically added to the embedded maps bundles.
+/**
+ * Adds statsgrid info bundle to all default/user appsetups
+ */
+public class V1_0_0__add_statsgrid_bundle extends BaseJavaMigration {
 
-Remember to add the statsgrid bundle to you minifierAppSetup.json as well under the frontend code Oskari/applications/your/app/minifierAppSetup.json for both geoportal  and embedded map apps. This bundle doesn't have map-engine dependency so you can use the same snippet for both:
-
-    {
-        "bundlename": "statsgrid",
-        "metadata": {
-            "Import-Bundle": {
-                "statsgrid": {
-                    "bundlePath": "/Oskari/packages/statistics/"
-                }
-            }
-        }
+    public void migrate(Context context) throws Exception {
+        AppSetupHelper.addBundleToApps(context.getConnection(), "statsgrid");
     }
+}
+```
 
-The sample application has it included as an example: https://github.com/oskariorg/oskari-frontend/blob/1.40.0/applications/sample/servlet/minifierAppSetup.json#L578-L587. Remember to add mapstats from the previous step to the minifierAppSetup.json as well:
+Note that you need to change the package to match your applications module (in the sample-server-extension the module is called `example` and it's located here: https://github.com/oskariorg/sample-server-extension/tree/master/app-resources/src/main/java/flyway/example). You will also need to change the version number (in the class name) to match your application. Picking the next number from the current version is ok. If this is your first migration for the app you will also need to define the module to be activated in `oskari-ext.properties`:
 
-https://github.com/oskariorg/oskari-frontend/blob/1.40.0/applications/sample/servlet/minifierAppSetup.json#L71-L73
+```
+db.additional.modules=myplaces, userlayer, [your module]
+```
 
-https://github.com/oskariorg/oskari-frontend/blob/1.40.0/applications/sample/servlet_published_ol3/minifierAppSetup.json#L12-L14
+If you want to test is out before doing the Flyway-migration on the server side you can also add it to a single appsetup by running the below SQL. We recommend using Flyway-migration as you will most likely want to add it to any appsetups the user might have saved in addition to the default appsetup. Replace [appsetup_id] in the SQL below with the id of your default appsetup:
 
-After this you should have the bundle included in both minifierAppSetups and the actual GetAppSetup response (database table portti_view_bundle_seq). 
+    INSERT INTO oskari_appsetup_bundles (appsetup_id, seqno, bundle_id, config, state)
+           VALUES ([appsetup_id],
+            (SELECT (max(seqno) + 1) FROM oskari_appsetup_bundles WHERE appsetup_id = [appsetup_id]),
+            (SELECT id FROM oskari_bundle WHERE name = 'statsgrid'),
+            (SELECT config FROM oskari_bundle WHERE name = 'statsgrid'),
+            (SELECT state FROM oskari_bundle WHERE name = 'statsgrid'));
+
+*Note!* You don't need to add the bundle to publish-template or any embedded maps. If the user decides to publish a thematic map, the bundle is automatically added to the embedded maps bundles.
 
 ## oskari-server/Maven dependencies
 
 The server-side code for thematic maps are included by default on the sample application, but if you have an oskari-server-extension (like you propably should) make sure you have the dependencies included in the webapp-map/pom.xml:
 
-        <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>oskari-control-statistics</artifactId>
-            <version>${oskari.version}</version>
-        </dependency>
-        <!-- Statistics plugins -->
-        <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>oskari-statistics-eurostat</artifactId>
-            <version>${oskari.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>service-statistics-pxweb</artifactId>
-            <version>${oskari.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>oskari-statistics-sotka</artifactId>
-            <version>${oskari.version}</version>
-        </dependency>
-        <!-- /Statistics plugins -->
+```xml
+<dependency>
+    <groupId>org.oskari</groupId>
+    <artifactId>control-statistics</artifactId>
+    <version>${oskari.version}</version>
+</dependency>
+<!-- Statistics plugins -->
+<dependency>
+    <groupId>org.oskari</groupId>
+    <artifactId>service-statistics-pxweb</artifactId>
+    <version>${oskari.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.oskari</groupId>
+    <artifactId>service-statistics-unsd</artifactId>
+    <version>${oskari.version}</version>
+</dependency>
+<!-- /Statistics plugins -->
+```
 
-Take a look at the sample webapp-map for details: https://github.com/oskariorg/oskari-server/blob/1.40.0/webapp-map/pom.xml#L58-L71. There might be additional adapters available also. Take a look at the folders under oskari-server starting with 'service-statistics-'.
+Take a look at the sample webapp-map for details: https://github.com/oskariorg/sample-server-extension/blob/1.4.1/webapp-map/pom.xml#L56-L69. There might be additional adapters available also. Take a look at the folders under oskari-server starting with 'service-statistics-'.
 
 # Next step
 


### PR DESCRIPTION
Remove references to OpenLayers 2, minifierAppSetup.json, portti_view -> oskari_appsetup etc. Add instructions for main.js and other current files.