### PR TITLE
Update style doc to match code

### DIFF
--- a/md/documentation/examples/oskari-style.md
+++ b/md/documentation/examples/oskari-style.md
@@ -23,12 +23,13 @@ All of the fields and objects defined here are optional in the Oskari style JSON
         "color": "#000000", // stroke color
         "width": 1, // stroke width
         "lineDash": "solid", // line dash, supported: dash, dashdot, dot, longdash, longdashdot and solid
-        "lineCap": "round", // line cap, supported: mitre, round and square
+        "lineCap": "round", // line cap, supported: butt, round and square
+        "lineJoin": "round" // line corner, supported: bevel, round and miter
         "area": {
             "color": "#000000", // area stroke color
             "width": 1, // area stroke width
             "lineDash": "dot", // area line dash
-            "lineJoin": "round" // area line corner
+            "lineJoin": "round" // area line corner, supported: bevel, round and miter
         }
     },
     "text": { // text style


### PR DESCRIPTION
See oskariorg/oskari-frontend#1642

Openlayers:
- Line cap style: butt, round, or square. (defaults to 'round')
- Line join style: bevel, round, or miter. (defaults to 'round')

Map style parsing:
https://github.com/oskariorg/oskari-frontend/blob/2.4.0/bundles/mapping/mapmodule/oskariStyle/generator.ol.js#L179-L181

Printing:
Linecap: https://github.com/oskariorg/oskari-server/blob/2.4.0/service-print/src/main/java/org/oskari/print/request/PDPrintStyle.java#L180-L184

Linejoin: https://github.com/oskariorg/oskari-server/blob/2.4.0/service-print/src/main/java/org/oskari/print/request/PDPrintStyle.java#L201-L206